### PR TITLE
Fix: Text and body overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,10 +3,11 @@ html {
 }
 body {
   font-family: "Montserrat", sans-serif;
-  width: 800px;
+  max-width: 800px;
   margin: 2px auto;
   background-color: rgb(248, 206, 90);
   border: 1px solid black;
+  padding: 10px;
 }
 
 h1 {
@@ -18,7 +19,7 @@ h1 {
 
 p {
   font-size: 20px;
-  width: 700px;
+  max-width: 700px;
   line-height: 1.5;
   margin: 0 auto;
   text-align: justify;


### PR DESCRIPTION
Prevent the text and the body from overflowing when the browser window is smaller when 800 or 700px